### PR TITLE
Prevent writes to event buffer after cleanup

### DIFF
--- a/driver/daita.c
+++ b/driver/daita.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2023 Mullvad AB. All Rights Reserved.
+ * Copyright (C) 2024 Mullvad AB. All Rights Reserved.
  *
  * DAITA - Defence Against AI-Guided Traffic Analysis
  */

--- a/driver/daita.c
+++ b/driver/daita.c
@@ -539,8 +539,6 @@ DaitaClose(_Inout_ WG_DEVICE *Wg)
     WriteBooleanNoFence(&Wg->Daita.Enabled, FALSE);
 
     KeReleaseSpinLock(&Wg->Daita.Event.Lock, OldIrql);
-
-    RtlZeroMemory(&Wg->Daita, sizeof(Wg->Daita));
 }
 
 #ifdef ALLOC_PRAGMA

--- a/driver/daita.c
+++ b/driver/daita.c
@@ -305,7 +305,7 @@ DaitaActivate(_In_ DEVICE_OBJECT *DeviceObject, _Inout_ IRP *Irp)
 
     Irp->IoStatus.Information = 0;
 
-    if (!HasAccess(FILE_WRITE_DATA, Irp->RequestorMode, &Irp->IoStatus.Status))
+    if (!HasAccess(FILE_WRITE_DATA, Irp->RequestorMode, &Status))
         goto cleanup;
 
     IO_STACK_LOCATION *Stack = IoGetCurrentIrpStackLocation(Irp);

--- a/driver/daita.h
+++ b/driver/daita.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2023 Mullvad AB. All Rights Reserved.
+ * Copyright (C) 2024 Mullvad AB. All Rights Reserved.
  *
  * DAITA - Defence Against AI-Guided Traffic Analysis
  */

--- a/driver/daita_internal.h
+++ b/driver/daita_internal.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2023 Mullvad AB. All Rights Reserved.
+ * Copyright (C) 2024 Mullvad AB. All Rights Reserved.
  *
  * DAITA - Defence Against AI-Guided Traffic Analysis
  */

--- a/driver/daita_internal.h
+++ b/driver/daita_internal.h
@@ -124,6 +124,8 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 DaitaPaddingReceived(_In_ WG_PEER *Peer, ULONG Length);
 
+_Requires_lock_not_held_(Wg->Daita.Event.Lock)
+_IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 DaitaClose(_Inout_ WG_DEVICE *Wg);
 


### PR DESCRIPTION
Changes:
* Fix: Received packets could rarely cause writes to unlocked/freed pages used by the event buffer (leading to a "page fault" BSOD).
* Minor: An incorrect error status was returned when denied access to the IOCTL.
* Minor: Don't clean up DAITA context on `IRP_MN_QUERY_REMOVE_DEVICE`/`IRP_MN_SURPRISE_REMOVAL`. The halt handler should suffice.