### PR TITLE
Apply multihop patch more strictly

### DIFF
--- a/api/configuration.c
+++ b/api/configuration.c
@@ -108,6 +108,12 @@ static_assert(
 static_assert(
     RTL_FIELD_SIZE(WG_IOCTL_PEER, AllowedIPsCount) == RTL_FIELD_SIZE(WIREGUARD_PEER, AllowedIPsCount),
     "Peer->AllowedIPsCount struct mismatch");
+static_assert(
+    offsetof(WG_IOCTL_PEER, Multihop) == offsetof(WIREGUARD_PEER, Multihop),
+    "Peer->Multihop struct mismatch");
+static_assert(
+    RTL_FIELD_SIZE(WG_IOCTL_PEER, Multihop) == RTL_FIELD_SIZE(WIREGUARD_PEER, Multihop),
+    "Peer->Multihop struct mismatch");
 static_assert(WG_IOCTL_PEER_HAS_PUBLIC_KEY == WIREGUARD_PEER_HAS_PUBLIC_KEY, "PEER_HAS_PUBLIC_KEY flag mismatch");
 static_assert(
     WG_IOCTL_PEER_HAS_PRESHARED_KEY == WIREGUARD_PEER_HAS_PRESHARED_KEY,

--- a/api/wireguard.h
+++ b/api/wireguard.h
@@ -245,6 +245,7 @@ struct ALIGNED(8) _WIREGUARD_PEER
     DWORD64 RxBytes;                         /**< Number of bytes received */
     DWORD64 LastHandshake;                   /**< Time of the last handshake, in 100ns intervals since 1601-01-01 UTC */
     DWORD AllowedIPsCount;                   /**< Number of allowed IP structs following this struct */
+    BOOLEAN Multihop;                        /**< If true, 'endpoint' may be routed to the wireguard interface itself */
 };
 
 typedef enum

--- a/driver/ioctl.c
+++ b/driver/ioctl.c
@@ -163,11 +163,13 @@ Get(_In_ DEVICE_OBJECT *DeviceObject, _Inout_ IRP *Irp)
             {
                 IoctlPeer->Endpoint.Ipv4 = Peer->Endpoint.Addr.Ipv4;
                 IoctlPeer->Flags |= WG_IOCTL_PEER_HAS_ENDPOINT;
+                IoctlPeer->Multihop = Peer->Multihop;
             }
             else if (Peer->Endpoint.Addr.si_family == AF_INET6)
             {
                 IoctlPeer->Endpoint.Ipv6 = Peer->Endpoint.Addr.Ipv6;
                 IoctlPeer->Flags |= WG_IOCTL_PEER_HAS_ENDPOINT;
+                IoctlPeer->Multihop = Peer->Multihop;
             }
             ExReleaseSpinLockShared(&Peer->EndpointLock, Irql);
         }
@@ -331,6 +333,8 @@ SetPeer(_Inout_ WG_DEVICE *Wg, _Inout_ CONST volatile WG_IOCTL_PEER **UnsafeIoct
 
     if (IoctlPeer.Flags & WG_IOCTL_PEER_HAS_ENDPOINT)
     {
+        Peer->Multihop = IoctlPeer.Multihop;
+
         SIZE_T Size;
         if ((Size = sizeof(SOCKADDR_IN), IoctlPeer.Endpoint.si_family == AF_INET) ||
             (Size = sizeof(SOCKADDR_IN6), IoctlPeer.Endpoint.si_family == AF_INET6))

--- a/driver/ioctl.h
+++ b/driver/ioctl.h
@@ -57,6 +57,7 @@ typedef __declspec(align(8)) struct _WG_IOCTL_PEER
     ULONG64 RxBytes;
     ULONG64 LastHandshake;
     ULONG AllowedIPsCount;
+    BOOLEAN Multihop;
 } WG_IOCTL_PEER;
 
 typedef enum

--- a/driver/peer.h
+++ b/driver/peer.h
@@ -72,6 +72,7 @@ typedef struct _WG_PEER
     LIST_ENTRY PeerList;
     LIST_ENTRY AllowedIpsList;
     UINT64 InternalId;
+    BOOLEAN Multihop;
 } WG_PEER;
 
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/driver/receive.c
+++ b/driver/receive.c
@@ -55,6 +55,7 @@ ReceiveHandshakePacket(_Inout_ WG_DEVICE *Wg, _In_ NET_BUFFER_LIST *Nbl)
     }
     else if (LastUnderLoad)
     {
+        /* set UnderLoad to false if at least 1 sec since it was last set to true */
         UnderLoad = !BirthdateHasExpired(LastUnderLoad, 1);
         if (!UnderLoad)
             LastUnderLoad = 0;

--- a/driver/socket.c
+++ b/driver/socket.c
@@ -180,10 +180,10 @@ SocketResolvePeerEndpoint(_Inout_ WG_PEER *Peer, _Out_ _At_(*Irql, _IRQL_saves_)
 retryWhileHoldingSharedLock:
     if ((Peer->Endpoint.Addr.si_family == AF_INET &&
          Peer->Endpoint.RoutingGeneration == (UINT32)ReadNoFence(&RoutingGenerationV4) &&
-         Peer->Endpoint.Src4.ipi_ifindex) ||
+         Peer->Endpoint.Src4.ipi_ifindex && (Peer->Endpoint.Src4.ipi_ifindex != Peer->Device->InterfaceIndex && !Peer->Multihop)) ||
         (Peer->Endpoint.Addr.si_family == AF_INET6 &&
          Peer->Endpoint.RoutingGeneration == (UINT32)ReadNoFence(&RoutingGenerationV6) &&
-         Peer->Endpoint.Src6.ipi6_ifindex))
+         Peer->Endpoint.Src6.ipi6_ifindex && (Peer->Endpoint.Src6.ipi6_ifindex != Peer->Device->InterfaceIndex && !Peer->Multihop)))
         return STATUS_SUCCESS;
 
     SOCKADDR_INET Addr;
@@ -206,8 +206,7 @@ retryWhileHoldingSharedLock:
         return STATUS_INSUFFICIENT_RESOURCES;
     for (ULONG i = 0; i < Table->NumEntries; ++i)
     {
-        if (Table->Table[i].InterfaceLuid.Value == Peer->Device->InterfaceLuid.Value &&
-            Table->Table[i].DestinationPrefix.PrefixLength == 0)
+        if (Table->Table[i].InterfaceLuid.Value == Peer->Device->InterfaceLuid.Value && !Peer->Multihop)
             continue;
         if (Table->Table[i].DestinationPrefix.PrefixLength < BestCidr)
             continue;
@@ -449,6 +448,9 @@ SocketSendBufferAsReplyToNbl(WG_DEVICE *Wg, CONST NET_BUFFER_LIST *InNbl, CONST 
     if (!NT_SUCCESS(Status))
         goto cleanupMdl;
     Status = STATUS_BAD_NETWORK_PATH;
+    if ((Endpoint.Addr.si_family == AF_INET && Endpoint.Src4.ipi_ifindex == Wg->InterfaceIndex) ||
+        (Endpoint.Addr.si_family == AF_INET6 && Endpoint.Src6.ipi6_ifindex == Wg->InterfaceIndex))
+        goto cleanupMdl;
     KIRQL Irql = RcuReadLock();
     SOCKET *Socket = NULL;
     if (Endpoint.Addr.si_family == AF_INET)
@@ -594,6 +596,7 @@ SocketSetPeerEndpoint(WG_PEER *Peer, CONST ENDPOINT *Endpoint)
     if (Endpoint->Addr.si_family == AF_INET)
     {
         Peer->Endpoint.Addr.Ipv4 = Endpoint->Addr.Ipv4;
+        if (Endpoint->Src4.ipi_ifindex != Peer->Device->InterfaceIndex)
         {
             Peer->Endpoint.Cmsg = Endpoint->Cmsg;
             Peer->Endpoint.Src4 = Endpoint->Src4;
@@ -603,6 +606,7 @@ SocketSetPeerEndpoint(WG_PEER *Peer, CONST ENDPOINT *Endpoint)
     else if (Endpoint->Addr.si_family == AF_INET6)
     {
         Peer->Endpoint.Addr.Ipv6 = Endpoint->Addr.Ipv6;
+        if (Endpoint->Src6.ipi6_ifindex != Peer->Device->InterfaceIndex)
         {
             Peer->Endpoint.Cmsg = Endpoint->Cmsg;
             Peer->Endpoint.Src6 = Endpoint->Src6;


### PR DESCRIPTION
This mostly reverts f1ff2104063d41c188027d8b164d8f13792c1083. Rather than unconditionally applying the patch, it is only applied if the peer has a flag set (`Multihop`). Not perfect, but it should eliminate the issue if peers are properly set up.